### PR TITLE
Dynamically generate format strings

### DIFF
--- a/@msdanalyzer/computeMSD.m
+++ b/@msdanalyzer/computeMSD.m
@@ -37,11 +37,13 @@ if ~isempty(obj.drift)
     xdrift = obj.drift(:, 2:end);
 end
 
-fprintf('%5d/%5d', 0, n_tracks);
+[numSpec,bkspSpec] = makeformatSpec( max(5, ceil(log10(n_tracks))) );
+fprintf(numSpec, 0, n_tracks);
+updateSpec = [bkspSpec numSpec];
 
 for i = 1 : n_tracks
     
-    fprintf('\b\b\b\b\b\b\b\b\b\b\b%5d/%5d', i, n_tracks);
+    fprintf(updateSpec, i, n_tracks);
     
     mean_msd    = zeros(n_delays, 1);
     M2_msd2     = zeros(n_delays, 1);
@@ -107,7 +109,7 @@ for i = 1 : n_tracks
     obj.msd{index} = [ delays mean_msd std_msd n_msd ];
     
 end
-fprintf('\b\b\b\b\b\b\b\b\bDone.\n')
+fprintf([bkspSpec 'Done.\n'])
 
 obj.msd_valid = true;
 

--- a/@msdanalyzer/computeVCorr.m
+++ b/@msdanalyzer/computeVCorr.m
@@ -31,9 +31,11 @@ n_delays = numel(delays);
 n_tracks = numel(velocities);
 
 fprintf('Computing velocity autocorrelation of %d tracks... ', n_tracks);
-fprintf('%4d/%4d', 0, n_tracks);
+[numSpec,bkspSpec] = makeformatSpec( max(4, ceil(log10(n_tracks))) );
+fprintf(numSpec, 0, n_tracks);
+updateSpec = [bkspSpec numSpec];
 for i = 1 : n_tracks
-    fprintf('\b\b\b\b\b\b\b\b\b%4d/%4d', i, n_tracks);
+    fprintf(updateSpec, i, n_tracks);
     
     % Holder for mean, std calculations
     sum_vcorr     = zeros(n_delays-1, 1);
@@ -82,7 +84,7 @@ for i = 1 : n_tracks
     obj.vcorr{index} = vcorrelation;
     
 end
-fprintf('\b\b\b\b\b\b\b\b\bDone.\n')
+fprintf([bkspSpec 'Done.\n'])
 
 obj.vcorr_valid = true;
 

--- a/@msdanalyzer/fitLogLogMSD.m
+++ b/@msdanalyzer/fitLogLogMSD.m
@@ -47,10 +47,12 @@ alpha_upperci = NaN(n_spots, 1);
 alpha_lowerci = NaN(n_spots, 1);
 ft = fittype('poly1');
 
-fprintf('%5d/%5d', 0, n_spots);
+[numSpec,bkspSpec] = makeformatSpec( max(5, ceil(log10(n_tracks))) );
+fprintf(numSpec, 0, n_tracks);
+updateSpec = [bkspSpec numSpec];
 for i_spot = 1 : n_spots
     
-    fprintf('\b\b\b\b\b\b\b\b\b\b\b%5d/%5d', i_spot, n_spots);
+    fprintf(updateSpec, i_spot, n_spots);
     
     msd_spot = obj.msd{i_spot};
     
@@ -102,7 +104,7 @@ for i_spot = 1 : n_spots
     alpha_upperci(i_spot) = ci(2, 1);
     
 end
-fprintf('\b\b\b\b\b\b\b\b\b\b\bDone.\n')
+fprintf([bkspSpec 'Done.\n'])
 
 obj.loglogfit = struct(...
     'alpha', alpha, ...

--- a/@msdanalyzer/fitMSD.m
+++ b/@msdanalyzer/fitMSD.m
@@ -43,10 +43,12 @@ b = NaN(n_spots, 1);
 r2fit = NaN(n_spots, 1);
 ft = fittype('poly1');
 
-fprintf('%5d/%5d', 0, n_spots);
+[numSpec,bkspSpec] = makeformatSpec( max(5, ceil(log10(n_tracks))) );
+fprintf(numSpec, 0, n_tracks);
+updateSpec = [bkspSpec numSpec];
 for i_spot = 1 : n_spots
     
-    fprintf('\b\b\b\b\b\b\b\b\b\b\b%5d/%5d', i_spot, n_spots);
+    fprintf(updateSpec, i_spot, n_spots);
     
     msd_spot = obj.msd{i_spot};
     
@@ -81,7 +83,7 @@ for i_spot = 1 : n_spots
     r2fit(i_spot) = gof.adjrsquare;
     
 end
-fprintf('\b\b\b\b\b\b\b\b\bDone.\n')
+fprintf([bkspSpec 'Done.\n'])
 
 obj.lfit = struct(...
     'a', a, ...

--- a/@msdanalyzer/private/makeformatSpec.m
+++ b/@msdanalyzer/private/makeformatSpec.m
@@ -1,0 +1,10 @@
+function [numSpec,bkspSpec] = makeformatSpec(n_digits)
+%MAKEFORMATSPEC Create reusable formatSpec that prints and deletes x/x.
+
+assert(n_digits > 0)
+assert(n_digits == round(n_digits))
+
+dSpec = sprintf('%%%dd', n_digits);       % '%3d'
+numSpec = [dSpec '/' dSpec];              % '%3d/%3d'
+bkspSpec = repmat('\b', 1, 2*n_digits + 1);  % '\b\b\b\b\b\b\b'
+end


### PR DESCRIPTION
Added a private function to generate '%4d/%4d' and the correct number of '\b's in `computeMSD`, `computeVCorr`, `fitMSD` and `fitLogLogMSD`.

Currently computeVCorr has hardcoded '%4d' and 9 '\b's, and thus displays crazy things when there are >9999 tracks to work on. The rest three would do the same for >99999.